### PR TITLE
9477 - Fix static path issue

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -132,7 +132,7 @@ oracle.jar=C:/workspace/HEAD/for_development/bisdevsrv28/jboss/server/infra/lib/
         <property name="compile.dir" value="${output.dir}/classes" />
         <property name="exposed.dir" value="${output.dir}/exposed" />
         <property name="gensrc.dir" value="${output.dir}/gensrc" />
-        <property name="dist.dir" value="${work.dir}/dist" />
+        <property name="dist.dir" value="/jython" />
         <property name="apidoc.dir" value="${dist.dir}/Doc/javadoc" />
         <property name="junit.reports" value="${dist.dir}/testreports" />
         <property name="junit.htmlreports" value="${dist.dir}/test-html-reports" />

--- a/maven/build.xml
+++ b/maven/build.xml
@@ -32,7 +32,7 @@
   <property file="${user.home}/ant.properties" />
   <property file="${basedir}/default.properties"/>
 
-  <property name="project.version" value="2.7.0.8"/>
+  <property name="project.version" value="2.7.0.9"/>
 
   <property name="m2.repo" value="${user.home}/.m2/repository"/>
   <property name="m2.groupDir" value="org/python"/>

--- a/maven/build.xml
+++ b/maven/build.xml
@@ -39,7 +39,7 @@
 
   <property name="build.base" value="${basedir}/build"/>
   <property name="build.dir" value="${build.base}/maven"/>
-  <property name="dist.base" value="${basedir}/dist"/>
+  <property name="dist.base" value="/jython"/>
   <property name="src.dir" value="${basedir}/src"/>
 
   <condition property="do.build">


### PR DESCRIPTION
By deploying to /jython we at least get the path consistent (e.g. `/jython/Lib/_ssl.py`) instead of local dev paths. Jim Baker will look at http://bugs.jython.org/issue2535 shortly, but has said that it will actually be major changes to how they currently build stack traces.